### PR TITLE
指定使用Redis时使用的数据库及添加必要的环境变量说明。

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@
     cd docker
     docker-compose -f docker-compose-build.yml up -d
 
+# 环境变量说明
+==以下环境变量必须全部填写==
+|环境变量|说明|
+|---     |--- |
+|DB_HOST |数据库地址|
+|DB_PORT |数据库端口|
+|DB_NAME |数据库名  |
+|DB_USER |数据库用户|
+|DB_PASSWORD |数据库密码|
+|REDIS_HOST |Redis地址|
+|REDIS_PORT |Redis端口|
+|REDIS_CACHES |指定Redis所使用的数据库|
+|REDIS_CHANNEL |同上|

--- a/overrides.py
+++ b/overrides.py
@@ -6,7 +6,7 @@ ALLOWED_HOSTS = ['127.0.0.1']
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://"+ os.getenv('REDIS_HOST') + ":" + os.getenv('REDIS_PORT') + "/1",
+        "LOCATION": "redis://"+ os.getenv('REDIS_HOST') + ":" + os.getenv('REDIS_PORT') + "/"  + os.getenv('REDIS_CACHES'),
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }
@@ -17,7 +17,7 @@ CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [(os.getenv('REDIS_HOST'), os.getenv('REDIS_PORT'))],
+            "hosts": ["redis://"+ os.getenv('REDIS_HOST') + ":" + os.getenv('REDIS_PORT') + "/"  + os.getenv('REDIS_CHANNEL'],
         },
     },
 }


### PR DESCRIPTION
# 更改
原镜像默认使用Redis默认使用“0”，“1”数据库，无法方便更改使用的数据库，因此添加此项功能。
# 问题
所有环境变量必须全部手工配置，想要不设置`REDIS_CACHES` `REDIS_CHANNEL`就使用0，1，但不知道怎么做。
# 代码
docker-compose.yml 
```
version: '3'
services:
  spug:
    image: hyr326/spug:latest
    container_name: spug-1
    restart: always
    ports:
      - 8090:80
    environment:
      DB_HOST: xxx
      DB_PORT: 3306
      DB_NAME: spug-db
      DB_USER: spug
      DB_PASSWORD: xxx
      REDIS_HOST: xxx
      REDIS_PORT: 6379
      REDIS_CACHES: 244
      REDIS_CHANNEL: 243
    volumes:
      - ./config/overrides.py:/data/spug/spug_api/spug/overrides.py
```
overrides.py
```
import os

DEBUG = False
ALLOWED_HOSTS = ['127.0.0.1']

CACHES = {
    "default": {
        "BACKEND": "django_redis.cache.RedisCache",
        "LOCATION": "redis://"+ os.getenv('REDIS_HOST') + ":" + os.getenv('REDIS_PORT') + "/"  + os.getenv('REDIS_CACHES'),
        "OPTIONS": {
            "CLIENT_CLASS": "django_redis.client.DefaultClient",
        }
    }
}

CHANNEL_LAYERS = {
    "default": {
        "BACKEND": "channels_redis.core.RedisChannelLayer",
        "CONFIG": {
            "hosts": ["redis://"+ os.getenv('REDIS_HOST') + ":" + os.getenv('REDIS_PORT') + "/"  + os.getenv('REDIS_CHANNEL')],
        },
    },
}

DATABASES = {
    'default': {
        'ATOMIC_REQUESTS': True,
        'ENGINE': 'django.db.backends.mysql',
        'NAME': os.getenv('DB_NAME'),             # 替换为自己的数据库名，请预先创建好编码为utf8mb4的数据库
        'USER': os.getenv('DB_USER'),        # 数据库用户名
        'PASSWORD': os.getenv('DB_PASSWORD'),  # 数据库密码
        'HOST': os.getenv('DB_HOST'),        # 数据库地址
        'PORT': os.getenv('DB_PORT'),             # 数据库端口号
        'OPTIONS': {
            'charset': 'utf8mb4',
            'sql_mode': 'STRICT_TRANS_TABLES',
            #'unix_socket': '/opt/mysql/mysql.sock' # 如果是本机数据库,且不是默认安装的Mysql,需要指定Mysql的socket文件路径
        }
    }
}
```